### PR TITLE
Fixed a bug of player jumping after he stops climbing *any* hill.

### DIFF
--- a/src/ZkGame/Entities/PlayerEntity.cpp
+++ b/src/ZkGame/Entities/PlayerEntity.cpp
@@ -250,11 +250,8 @@ void PlayerEntity::update(double step)
 	}
 
 	//Jeśli nie biegniemy i jesteśmy na ziemi, powinniśmy szybko spowolnić nasz bieg
-	if (isStanding && !isRunning)
-	{
-		b2Vec2 velocity = getBody()->GetLinearVelocity();
-		getBody()->SetLinearVelocity(b2Vec2(0.f, velocity.y));
-	}
+	if (isStanding && !isRunning && jumpCooldown == 0.f)
+		getBody()->SetLinearVelocity(b2Vec2(0.f, 0.f));
 
 	//Aktualizacja broni
 	sf::Vector2f direction =


### PR DESCRIPTION
Also accidentally restored original intention of jumps following a normal to the ground.
The bug was that the logical condition for player standing on the ground and not running didn't take jumps into account.
Closes #16.
