### PR TITLE
Fixed #issue3

### DIFF
--- a/src/ZkGame/Entities/CrateEntity.cpp
+++ b/src/ZkGame/Entities/CrateEntity.cpp
@@ -41,6 +41,11 @@ CrateEntity::CrateEntity(sf::Vector2f pos, sf::Vector2f size, const char * imgSr
 	setRenderable(br);
 }
 
+EntityType CrateEntity::getType() const
+{
+	return EntityType::CrateEntity;
+}
+
 CrateEntity::~CrateEntity()
 {
 

--- a/src/ZkGame/Entities/CrateEntity.h
+++ b/src/ZkGame/Entities/CrateEntity.h
@@ -15,6 +15,7 @@ public:
 	CrateEntity(sf::Vector2f pos, sf::Vector2f size, const char * imgSrc);
 	virtual ~CrateEntity();
 
+	virtual EntityType getType() const override;
 	virtual void pickUp() = 0;
 };
 

--- a/src/ZkGame/Entities/Entity.cpp
+++ b/src/ZkGame/Entities/Entity.cpp
@@ -57,6 +57,13 @@ void Entity::setBody(b2Body * b)
 	body = b;
 }
 
+EntityType Entity::getType() const
+{
+	//connected with #issue3
+	//printf("Entity getType called\n");
+	return EntityType::Unknown;
+}
+
 void Entity::markForDeletion()
 {
 	wannaDelete = true;

--- a/src/ZkGame/Entities/Entity.h
+++ b/src/ZkGame/Entities/Entity.h
@@ -45,7 +45,7 @@ public:
 	inline bool wantsToBeDeleted() const
 	{ return wannaDelete; }
 
-	virtual EntityType getType() const = 0;
+	virtual EntityType getType() const;
 
 protected:
 	void setRenderable(Renderable * r);


### PR DESCRIPTION
Currently game doesn't crash while simultaneous shooting and grenade throwing, it was caused by pure virtual function getType in Entity. Further investigation needed.
