### PR TITLE
Refactored PlayerUI::paint. Closes #8.

### DIFF
--- a/src/ZkGame/CMakeLists.txt
+++ b/src/ZkGame/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
 	Camera.cpp
 	Player.cpp
 	PlayerUI.cpp
+	PlayerUILayout.cpp
 	Physics.cpp
 	Game.cpp
 	GameSystem.cpp

--- a/src/ZkGame/Game.cpp
+++ b/src/ZkGame/Game.cpp
@@ -34,6 +34,7 @@
 #include "Weapons/Weapon.hpp"
 #include "Camera.hpp"
 
+
 using namespace Zk::Common;
 using namespace Zk::Game;
 

--- a/src/ZkGame/PlayerUI.cpp
+++ b/src/ZkGame/PlayerUI.cpp
@@ -7,6 +7,7 @@
 #include "../ZkCommon/Constants.hpp"
 
 #include "PlayerUI.hpp"
+#include "PlayerUILayout.hpp"
 #include "Entities/PlayerEntity.hpp"
 #include "Game.hpp"
 #include "GameSystem.hpp"
@@ -34,155 +35,11 @@ PlayerUI::PlayerUI(Player & player)
 
 PlayerUI::~PlayerUI()
 {
-
 }
 
 void PlayerUI::paint(sf::RenderTarget * rt)
 {
-	std::weak_ptr<PlayerEntity> pe = player.getPlayerEntity();
-
-	Camera * cam = Game::getInstance()->getCamera();
-	sf::View view = cam->getViews()[player.getID()];
-
-	//Modyfikujemy widok, gdyż potrzebne jest mierzenie
-	//długości/pozycji w pikselach
-	sf::Vector2f viewSize =
-		view.getSize() * (float)Constants::PIXELS_PER_METER;
-	view.reset(sf::FloatRect(0.f, 0.f, viewSize.x, viewSize.y));
-
-	sf::FloatRect area;
-	area.left = 0.f;
-	area.top = 0.f;
-	area.width = (float)viewSize.x;
-	area.height = (float)viewSize.y;
-
-	rt->setView(view);
-
-	double health;
-	double healthFraction;
-	double ammoFraction;
-	int numGrenades;
-
-	auto p = pe.lock();
-	if (p != nullptr)
-	{
-		const Weapon & weapon = p->getWeapon();
-
-		health = p->getHealth();
-
-		if (weapon.getAmmoCount() > 0)
-			ammoFraction =
-				(double)weapon.getAmmoCount() /
-				(double)weapon.getWeaponDef().clipSize;
-		else
-			ammoFraction = weapon.reloadProgress();
-
-		numGrenades = p->getGrenadeCount();
-	}
-	else
-	{
-		health = 0.0;
-		ammoFraction = 0.0;
-		numGrenades = 0;
-	}
-
-	healthFraction = health / 100.0;
-
-	sf::Vector2u htSize = healthTexture->getSize();
-	sf::Vector2u gtSize = grenadeTexture->getSize();
-	sf::Vector2u atSize = ammoTexture->getSize();
-
-	//Narysuj amunicję
-	sf::Sprite sprite;
-	sprite.setTexture(*ammoTexture, true);
-	sprite.setPosition(sf::Vector2f(
-		area.left,
-		area.top + area.height - atSize.y
-	));
-	rt->draw(sprite);
-
-	//Pasek amunicji
-	sf::RectangleShape rs;
-	rs.setPosition(sf::Vector2f(
-		area.left + htSize.x + 2.f,
-		area.top + area.height - atSize.y + 2.f
-	));
-	rs.setSize(sf::Vector2f((256.f - 4.f) * ammoFraction, atSize.y - 4.f));
-	rs.setOutlineColor(sf::Color::Transparent);
-	rs.setFillColor(sf::Color::Yellow);
-	rt->draw(rs);
-
-	rs.setSize(sf::Vector2f(256.f - 4.f, atSize.y - 4.f));
-	rs.setOutlineColor(sf::Color::Black);
-	rs.setFillColor(sf::Color::Transparent);
-	rs.setOutlineThickness(2.f);
-	rt->draw(rs);
-
-	//Narysuj życie
-	sprite.setTexture(*healthTexture, true);
-	sprite.setPosition(sf::Vector2f(
-		area.left,
-		area.top + area.height - atSize.y - htSize.y
-	));
-	rt->draw(sprite);
-
-	//Pasek życia
-	rs.setPosition(sf::Vector2f(
-		area.left + htSize.x + 2.f,
-		area.top + area.height - htSize.y - atSize.y + 2.f
-	));
-	rs.setSize(sf::Vector2f((256.f - 4.f) * healthFraction, htSize.y - 4.f));
-	rs.setOutlineColor(sf::Color::Transparent);
-	rs.setFillColor(sf::Color::Green);
-	rt->draw(rs);
-
-	rs.setSize(sf::Vector2f(256.f - 4.f, htSize.y - 4.f));
-	rs.setOutlineColor(sf::Color::Black);
-	rs.setFillColor(sf::Color::Transparent);
-	rs.setOutlineThickness(2.f);
-	rt->draw(rs);
-
-	//Narysuj granaty
-	for (int i = 0; i < numGrenades; i++)
-	{
-		sprite.setTexture(*grenadeTexture, true);
-		sprite.setPosition(sf::Vector2f(
-			area.left + (float)i * gtSize.x,
-			area.top + area.height - atSize.y - htSize.y - gtSize.y
-		));
-		rt->draw(sprite);
-	}
-
-	//Narysuj punktację
-	QString pointsString =
-		QString("%1 - %2").arg(player.getKillCount()).arg(player.getDeathCount());
-
-	sf::Text text;
-	text.setFont(font);
-	text.setString(pointsString.toStdString());
-	text.setCharacterSize(48);
-	sf::FloatRect rect = text.getLocalBounds();
-	text.setColor(sf::Color::Blue);
-	text.setPosition(
-		area.left + area.width - rect.width,
-		area.top + area.height - 48
-	);
-	rt->draw(text);
-
-	if (p == nullptr)
-	{
-		//Gracz nie żyje, więc wypisujemy ile zostało do respawnu
-		QString respawnString =
-			QString("Respawn in %1").arg(player.getSecondsToRespawn(), 0, 'f', 1);
-
-		text.setCharacterSize(48);
-		text.setString(respawnString.toStdString());
-		rect = text.getLocalBounds();
-		text.setPosition(
-			area.left + (area.width - rect.width) / 2.f,
-			area.top + (area.height - rect.height) / 2.f
-		);
-
-		rt->draw(text);
-	}
+	PlayerUILayout{rt, player, &font, healthTexture, grenadeTexture, ammoTexture}.paint();
 }
+
+

--- a/src/ZkGame/PlayerUILayout.cpp
+++ b/src/ZkGame/PlayerUILayout.cpp
@@ -1,0 +1,193 @@
+#include "PlayerUILayout.hpp"
+
+#include "../ZkCommon/Constants.hpp"
+
+#include "Entities/PlayerEntity.hpp"
+#include "Game.hpp"
+#include "GameSystem.hpp"
+#include "TextureCache.hpp"
+#include "Camera.hpp"
+
+#include "Weapons/Weapon.hpp"
+#include "Weapons/WeaponDef.hpp"
+
+using namespace Zk::Common;
+using namespace Zk::Game;
+
+PlayerUILayout::PlayerUILayout(sf::RenderTarget * rt, Player & player, const sf::Font * font,
+			       sf::Texture * healthTexture, sf::Texture * grenadeTexture,
+			       sf::Texture * ammoTexture)
+: rt{rt}, player{player}, font{font}, healthTexture{healthTexture}, grenadeTexture{grenadeTexture}
+, ammoTexture{ammoTexture}, atSize{ammoTexture->getSize()}, htSize{healthTexture->getSize()}
+, gtSize{grenadeTexture->getSize()}
+{
+	Camera * cam = Game::getInstance()->getCamera();
+	sf::View view = cam->getViews()[player.getID()];
+
+	//Modyfikujemy widok, gdyż potrzebne jest mierzenie
+	//długości/pozycji w pikselach
+	sf::Vector2f viewSize = view.getSize() * (float)Constants::PIXELS_PER_METER;
+	view.reset(sf::FloatRect(0.f, 0.f, viewSize.x, viewSize.y));
+
+	area.left = 0.f;
+	area.top = 0.f;
+	area.width = (float)viewSize.x;
+	area.height = (float)viewSize.y;
+
+	rt->setView(view);
+}
+
+
+void PlayerUILayout::paint()
+{
+	std::weak_ptr<PlayerEntity> pe = player.getPlayerEntity();
+
+	double health = 0.0;
+	double ammoFraction = 0.0;
+	int numGrenades = 0;
+
+	auto p = pe.lock();
+	if (p != nullptr)
+	{
+		const Weapon & weapon = p->getWeapon();
+
+		health = p->getHealth();
+
+		if (weapon.getAmmoCount() > 0)
+			ammoFraction =
+			(double)weapon.getAmmoCount() /
+			(double)weapon.getWeaponDef().clipSize;
+		else
+			ammoFraction = weapon.reloadProgress();
+
+		numGrenades = p->getGrenadeCount();
+	}
+
+
+	drawAmmoBar(ammoFraction);
+	drawHealthBar(health / 100.0);
+	drawGrenades(numGrenades);
+	drawPoints();
+
+	if (p == nullptr)
+	{
+		//Gracz nie żyje, więc wypisujemy ile zostało do respawnu
+		drawRespawnCounter();
+	}
+}
+
+void PlayerUILayout::drawAmmoBar(const double ammoFraction)
+{
+	//Narysuj amunicję
+	drawTexture(sf::Vector2f(
+		area.left,
+		area.top + area.height - atSize.y
+	), ammoTexture);
+
+	//Pasek amunicji
+	sf::FloatRect barArea(
+		area.left + htSize.x,
+		area.top + area.height - atSize.y,
+		256.f,
+		atSize.y
+	);
+	drawBar(barArea, ammoFraction, sf::Color::Yellow);
+}
+
+void PlayerUILayout::drawHealthBar(const double healthFraction)
+{
+	//Narysuj życie
+	drawTexture(sf::Vector2f(
+		area.left,
+		area.top + area.height - atSize.y - htSize.y
+	), healthTexture);
+
+	//Pasek życia
+	sf::FloatRect barArea(
+		area.left + htSize.x,
+		area.top + area.height - htSize.y - atSize.y,
+		256.f,
+		htSize.y
+	);
+	drawBar(barArea, healthFraction, sf::Color::Green);
+}
+
+void PlayerUILayout::drawGrenades(const int numGrenades)
+{
+	//Narysuj granaty
+	for (int i = 0; i < numGrenades; i++)
+		drawTexture(sf::Vector2f(
+			area.left + (float)i * gtSize.x,
+			area.top + area.height - atSize.y - htSize.y - gtSize.y
+		), grenadeTexture);
+}
+
+void PlayerUILayout::drawPoints()
+{
+	//Narysuj punktację
+	QString pointsString =
+	QString("%1 - %2").arg(player.getKillCount()).arg(player.getDeathCount());
+
+	drawText(pointsString.toStdString(), false, true);
+}
+
+void PlayerUILayout::drawRespawnCounter()
+{
+	QString respawnString =
+	QString("Respawn in %1").arg(player.getSecondsToRespawn(), 0, 'f', 1);
+
+	drawText(respawnString.toStdString(), true);
+}
+
+void PlayerUILayout::drawBar(const sf::FloatRect & barRect, const double fraction,
+			     const sf::Color & fillColor, const sf::Color & backgroundColor,
+			     const sf::Color & borderColor)
+{
+	sf::RectangleShape rs;
+	rs.setPosition(sf::Vector2f(barRect.left + 2.f, barRect.top + 2.f));
+
+	// Narysuj prostokąt
+	rs.setSize(sf::Vector2f(barRect.width - 4.f, barRect.height - 4.f));
+	rs.setOutlineColor(borderColor);
+	rs.setFillColor(backgroundColor);
+	rs.setOutlineThickness(2.f);
+	rt->draw(rs);
+
+	// Narysuj wypełnienie
+	rs.setSize(sf::Vector2f((barRect.width - 4.f) * fraction, barRect.height - 4.f));
+	rs.setOutlineColor(sf::Color::Transparent);
+	rs.setFillColor(fillColor);
+	rt->draw(rs);
+}
+
+void PlayerUILayout::drawTexture(const sf::Vector2f & position, const sf::Texture * texture)
+{
+	sf::Sprite sprite;
+	sprite.setTexture(*texture, true);
+	sprite.setPosition(position);
+	rt->draw(sprite);
+}
+
+void PlayerUILayout::drawText(const std::string & str, const bool centered, const bool toRight, const sf::Color & color)
+{
+	sf::Text text;
+	text.setFont(*font);
+	text.setCharacterSize(48);
+	text.setColor(color);
+	text.setString(str);
+	sf::FloatRect rect = text.getLocalBounds();
+	if (centered)
+		text.setPosition(sf::Vector2f(
+			area.left + (area.width - rect.width) / 2.f,
+					      area.top + (area.height - rect.height) / 2.f
+		));
+	else if (toRight) {
+		text.setPosition(sf::Vector2f(
+			area.left + area.width - rect.width,
+			area.top + area.height - 48
+		));
+	}
+
+	rt->draw(text);
+}
+

--- a/src/ZkGame/PlayerUILayout.hpp
+++ b/src/ZkGame/PlayerUILayout.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+
+#include "TextureCache.hpp"
+#include "Player.hpp"
+
+
+namespace Zk {
+namespace Game {
+
+/**
+ * @brief Klasa reprezentuje obiekt layoutu PlayerUI zainicjalizowanego wszystmimi danymi potrzebnymi do renderowania.
+ */
+class PlayerUILayout {
+public:
+	PlayerUILayout(
+		sf::RenderTarget * rt, Player & player, const sf::Font * font, sf::Texture * healthTexture,
+		sf::Texture * grenadeTexture, sf::Texture * ammoTexture);
+
+	void paint();
+
+private:
+	void drawAmmoBar(const double ammoFraction);
+	void drawHealthBar(const double healthFraction);
+	void drawGrenades(const int numGrenades);
+	void drawPoints();
+	void drawRespawnCounter();
+	void drawBar(const sf::FloatRect & barRect, const double fraction, const sf::Color & fillColor,
+		     const sf::Color & backgroundColor = sf::Color::Transparent,
+		     const sf::Color & borderColor = sf::Color::Black);
+	void drawTexture(const sf::Vector2f & position, const sf::Texture * texture);
+	void drawText(const std::string & str, const bool centered = false, const bool toRight = false,
+		      const sf::Color & color = sf::Color::Blue);
+
+	sf::RenderTarget * rt;
+	Player player;
+	const sf::Font * font;
+	const sf::Texture * healthTexture;
+	const sf::Texture * grenadeTexture;
+	const sf::Texture * ammoTexture;
+
+	sf::FloatRect area;
+	const sf::Vector2u atSize;
+	const sf::Vector2u htSize;
+	const sf::Vector2u gtSize;
+};
+
+}}


### PR DESCRIPTION
- removed most of the logic from PlayerUI,
- created PlayerUILayout class representing a ready-to-render layout with all necessary data,
- split the original paint logic to subprocedures for drawing bars, textures, text etc.
